### PR TITLE
Adding some improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "rec-jit"
 version = "0.1.0"
-authors = ["Adit Cahya Ramadhan <matematika.adit@gmail.com>"]
+authors = [
+    "Adit Cahya Ramadhan <matematika.adit@gmail.com>",
+    "Kurnia D Win <win@payfazz.com>",
+]
 description = """
 A Basic JIT-Compiler for a simple math recurrence relation based on
 https://nullprogram.com/blog/2015/03/19/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ For example typing in the stdin:
 10
 ```
 
+Or using sample `input.txt`:
+```console
+$ cargo run < input.txt
+```
+
 Is the same as calculating the recurrence `U[n] = (U[n-1] + 2) * 3`, with the initial
 value 0, and the number of iteration 10. Thus the program will give output:
 
@@ -81,6 +86,7 @@ The output then used to implement the corresponding operator and instruction.
 - Bot for executing this program
 - Make it works on Windows
 - RPN calculator
+- use LLVM
 
 ## License
 
@@ -88,5 +94,5 @@ Unlicense, see [UNLICENSE](/UNLICENSE) for more explanation.
 
 [Rust]: https://rustup.rs/
 [Playground Demo]: https://play.rust-lang.org/?gist=13c286c91e751227b2265fb499a96a66&version=stable&mode=debug&edition=2015
-[reddit thread]: http://redd.it/2z68di 
+[reddit thread]: http://redd.it/2z68di
 [mmap]: https://github.com/rbranson/rust-mmap

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,92 +1,132 @@
-/// Based on https://nullprogram.com/blog/2015/03/19/
-/// C version from the author: https://gist.github.com/skeeto/3a1aa3df31896c9956dc
-extern crate libc;
+//! Based on https://nullprogram.com/blog/2015/03/19/
+//! C version from the author: https://gist.github.com/skeeto/3a1aa3df31896c9956dc
 
-use std::ptr;
-use std::mem;
-use std::iter::Peekable;
-use std::marker::PhantomData;
-use libc::{
-    mmap, mprotect, munmap, c_void,
-    PROT_EXEC, PROT_READ, PROT_WRITE,
-    MAP_ANONYMOUS, MAP_PRIVATE,
-};
+// need to create a module, so private things cannot be accessed from ouside.
+mod asm_buf {
 
-const PAGE_SIZE: usize = 4096;
+    // hardcoded for now,
+    // if total opcode size bigger than this, it will panic
+    pub const BUF_SIZE: usize = 4096;
 
-struct AsmBuf {
-    begin: *mut u8,
-    cursor: *mut u8,
-}
+    use std::io::{Cursor, Write};
+    use std::mem::transmute;
+    use std::slice::from_raw_parts_mut;
 
-struct Fun<'a> {
-    inner: fn(i64) -> i64,
-    phantom: PhantomData<&'a mut AsmBuf>,
-}
+    extern crate libc;
+    use self::libc::{
+        mmap, mprotect, munmap, c_void,
+        PROT_EXEC, PROT_READ, PROT_WRITE,
+        MAP_ANONYMOUS, MAP_PRIVATE, MAP_FAILED,
+    };
 
-impl<'a> Fun<'a> {
-    fn call(&self, x: i64) -> i64 {
-        (self.inner)(x)
+    pub struct AsmBuf {
+        locked: bool,
+        cursor: Cursor<&'static mut [u8]>,
     }
-}
 
-impl AsmBuf {
-    fn new() -> AsmBuf {
+    pub fn new() -> AsmBuf {
         let prot = PROT_READ | PROT_WRITE;
         let flags = MAP_ANONYMOUS | MAP_PRIVATE;
-        let null = ptr::null_mut();
 
-        let begin = unsafe { mmap(null, PAGE_SIZE, prot, flags, -1, 0) } as *mut u8;
-        AsmBuf {
-            begin: begin,
-            cursor: begin,
+        let begin = unsafe { mmap(0 as *mut c_void, BUF_SIZE, prot, flags, -1, 0) };
+        assert_ne!(begin, MAP_FAILED, "Failed to mmap");
+        let data = unsafe { from_raw_parts_mut(begin as *mut u8, BUF_SIZE) };
+
+        let mut retval = AsmBuf {
+            locked: false,
+            cursor: Cursor::new(data),
+        };
+
+        retval.op_mov_rax_rdi();
+
+        retval
+    }
+
+    impl Drop for AsmBuf {
+        fn drop(&mut self) {
+            let data = self.cursor.get_mut();
+            let data_ptr = data.as_mut_ptr() as *mut c_void;
+            let data_len = data.len();
+            let retval = unsafe { munmap(data_ptr, data_len) };
+            assert_ne!(retval, -1, "Failed to munmap");
+            // basically, self.cursor is dangling pointer now
         }
     }
-    fn ins(&mut self, size: usize, ins: usize) {
-        for i in (0..size).rev() {
+
+    impl AsmBuf {
+        fn write(&mut self, buf: &[u8]) {
+            assert!(!self.locked, "AsmBuf are locked");
+            self.cursor.write_all(buf)
+                .expect("Failed to write, buffer overflow");
+        }
+
+        pub fn to_fn<'a>(&'a mut self) -> impl Fn(i64) -> i64 + 'a {
+            if !self.locked {
+                self.op_ret();
+
+                self.locked = true; // no write after this
+
+                let data = self.cursor.get_mut();
+                let data_ptr = data.as_mut_ptr() as *mut c_void;
+                let data_len = data.len();
+                let retval = unsafe { mprotect(data_ptr, data_len, PROT_READ | PROT_EXEC) };
+                assert_ne!(retval, -1, "Failed to mprotect");
+            }
             unsafe {
-                let val = (ins >> (i * 8)) as u8;
-                self.cursor.write(val);
-                self.cursor = self.cursor.add(1);
+                transmute::<_, fn(i64) -> i64>(self.cursor.get_mut().as_mut_ptr() as *mut c_void)
             }
         }
     }
-    fn immediate(&mut self, size: usize, value: i64) {
-        unsafe {
-            let value = &value as *const i64 as *const u8;
-            self.cursor.copy_from_nonoverlapping(value, size);
-            self.cursor = self.cursor.add(size);
-        }
-    }
-    fn to_fn(&mut self) -> Fun {
-        unsafe {
-            mprotect(self.begin as *mut c_void, PAGE_SIZE, PROT_READ | PROT_EXEC);
-            Fun {
-                inner: mem::transmute(self.begin),
-                phantom: PhantomData,
+
+    macro_rules! generate_op {
+        ($name:ident, $data:expr) => {
+            pub fn $name(&mut self) -> &mut Self {
+                self.write($data);
+                self
             }
+        };
+    }
+
+    impl AsmBuf{
+        // only some (safe) opcode allowed here,
+        // if we let arbitary opcode,
+        // then calling to fn returned by to_fn should be considered unsafe
+
+        generate_op!(op_add_rax_rdi, &[0x48, 0x01, 0xF8]);
+        generate_op!(op_and_rax_rdi, &[0x48, 0x21, 0xF8]);
+        generate_op!(op_idiv_rdi, &[0x48, 0xF7, 0xFF]);
+        generate_op!(op_imul_rax_rdi, &[0x48, 0x0F, 0xAF, 0xC7]);
+        generate_op!(op_mov_ecx_edi, &[0x89, 0xF9]);
+        generate_op!(op_mov_rax_rdi, &[0x48, 0x89, 0xF8]);
+        generate_op!(op_mov_rax_rdx, &[0x48, 0x89, 0xD0]);
+        generate_op!(op_not_rax, &[0x48, 0xF7 ,0xD0]);
+        generate_op!(op_or_rax_rdi, &[0x48, 0x09, 0xF8]);
+        generate_op!(op_ret, &[0xC3]);
+        generate_op!(op_shl_rax_cl, &[0x48, 0xD3, 0xE0]);
+        generate_op!(op_shr_rax_cl, &[0x48, 0xD3, 0xE8]);
+        generate_op!(op_sub_rax_rdi, &[0x48, 0x29, 0xF8]);
+        generate_op!(op_xor_rax_rdi, &[0x48, 0x31, 0xF8]);
+        generate_op!(op_xor_rdx_rdx, &[0x48, 0x31, 0xD2]);
+
+        pub fn op_mov_rdi_imm64(&mut self, imm: i64) -> &mut Self {
+            self.write(&[0x48, 0xBF]);
+            self.write(&unsafe { transmute::<i64, [u8; 8]>(imm) });
+            self
         }
     }
 }
 
-impl Drop for AsmBuf {
-    fn drop(&mut self) {
-        unsafe {
-            munmap(self.begin as *mut c_void, PAGE_SIZE);
-        }
-    }
-}
+
+use std::iter::Peekable;
+use std::io::Read;
 
 fn main() {
-    use std::io::Read;
     let mut buffer = String::new();
     std::io::stdin().read_to_string(&mut buffer).unwrap();
 
     let mut input = buffer.bytes().peekable();
 
-    let mut asmbuf = AsmBuf::new();
-
-    asmbuf.ins(3, 0x4889F8); // mov rax, rdi
+    let mut asmbuf = asm_buf::new();
 
     while let Some(c) = input.next() {
         if c == b'\n' {
@@ -102,62 +142,55 @@ fn main() {
         // not operator (!)
 
         if operator == b'!' {
-            asmbuf.ins(3, 0x48F7D0); // not rax
+            asmbuf.op_not_rax();
             continue; // not parsing the digit
         }
 
         // parse digit
         let operand = parse_digit(&mut input);
-
-        asmbuf.ins(2, 0x48BF); // mov rdi, operand
-        asmbuf.immediate(8, operand);
+        asmbuf.op_mov_rdi_imm64(operand);
 
         match operator {
-            b'+' => asmbuf.ins(3, 0x4801F8),   // add rax, rdi
-            b'-' => asmbuf.ins(3, 0x4829F8),   // sub rax, rdi
-            b'*' => asmbuf.ins(4, 0x480FAFC7), // imul rax, rdi
-            b'/' => {
-                    asmbuf.ins(3, 0x4831D2);   // xor rdx, rdx
-                    asmbuf.ins(3, 0x48F7FF);   // idiv rdi
-            },
+            b'+' => { asmbuf.op_add_rax_rdi(); },
+            b'-' => { asmbuf.op_sub_rax_rdi(); },
+            b'*' => { asmbuf.op_imul_rax_rdi(); },
+            b'/' => { asmbuf.op_xor_rdx_rdx()
+                            .op_idiv_rdi(); },
             // Exercise: implements
             // - mod (%)
             // - xor (^)
             // - shl (<)
             // - shr (>)
-            b'%' => {
-                    asmbuf.ins(3, 0x4831D2);   // xor rdx, rdx
-                    asmbuf.ins(3, 0x48F7FF);   // idiv rdi
-                    asmbuf.ins(3, 0x4889D0);   // mov rax, rdx
-            },
-            b'^' => asmbuf.ins(3, 0x4831F8),   // xor rax, rdi
-            b'<' => {
-                    asmbuf.ins(2, 0x89F9);     // mov ecx, edi
-                    asmbuf.ins(3, 0x48D3E0);   // shl rax, cl
-            },
-            b'>' => {
-                    asmbuf.ins(2, 0x89F9);     // mov ecx, edi
-                    asmbuf.ins(3, 0x48D3E8);   // shr rax, cl
-            },
+            b'%' => { asmbuf.op_xor_rdx_rdx()
+                            .op_idiv_rdi()
+                            .op_mov_rax_rdx(); },
+            b'^' => { asmbuf.op_xor_rax_rdi(); },
+            b'<' => { asmbuf.op_mov_ecx_edi()
+                            .op_shl_rax_cl(); },
+            b'>' => { asmbuf.op_mov_ecx_edi()
+                            .op_shr_rax_cl(); },
             // Extra: instruction
             // - and (&)
             // - or (|)
-            // - not (!) [no operand, written above]
-            b'&' => asmbuf.ins(3, 0x4821F8),   // and rax, rdi
-            b'|' => asmbuf.ins(3, 0x4809F8),   // or rax, rdi
+            // - not (!) [not operand, written above]
+            b'&' => { asmbuf.op_and_rax_rdi(); },
+            b'|' => { asmbuf.op_or_rax_rdi(); },
             _ => panic!("unkonwn operator"),
         }
     }
 
-    asmbuf.ins(1, 0xC3); // ret
     let fun = asmbuf.to_fn();
+
+    // try to uncoment this
+    // it should compile error, because fun cannot live longer than asmbuf
+    // drop(asmbuf);
 
     let init = parse_digit(&mut input);
     let term = parse_digit(&mut input);
     let mut x = init;
     for i in 0..term+1 {
         println!("Term {}: {}", i, x);
-        x = fun.call(x);
+        x = fun(x);
     }
 }
 


### PR DESCRIPTION
- use `Cursor<&'static mut [u8]>` for the mapped memory, so `unsafe` is only needed on `new`, `drop` and `to_fn`, `op_mov_rdi_imm64` can be implemented without `transmute`, but, it's easier this way.
- the user of the module, should not able to write arbitrary opcode, if they can, calling to function returned by `to_fn` should be considered `unsafe` due to similar to calling ffi function
- .bundle to one module, so private things cannot be accessed directly
- panic if the underlying libc function fail.
- lock the buffer after calling `to_fn`
- `to_fn` returning closure, instead of function.
- first `mov rax, rdi` and last `ret` are part of the buffer, the user doesn't need to write them to the buffer.